### PR TITLE
Fix typo and module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ include the typer directive source file in your html
 Mark the typer module as a dependecy of your angular app
 
 ```
-angular.moudle('myApp', ['revealer']);
+angular.module('myApp', ['typer']);
 
 ```
 


### PR DESCRIPTION
I noticed a typo when I was testing it out on plunker and I also noticed that the name of the module is wrong. So it was not working.